### PR TITLE
CASMINST-6859 pit-init.sh is skipping load_packages on vShasta

### DIFF
--- a/bin/pit-init.sh
+++ b/bin/pit-init.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022-2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -71,7 +71,7 @@ EOF
 #######################################
 function isgcp {
   # defaults to /etc/google_system, but can be overridden
-  _isgcp_identifier="etc/google_system"
+  _isgcp_identifier="/etc/google_system"
 
   # if the file exists, it is likely on GCP
   [ -e "${_isgcp_identifier}" ] && return 0
@@ -302,13 +302,13 @@ function load_and_start_systemd {
 }
 
 function main {
-  # vshasta does not need certain parts of pit-init or are they incompatible with it
-  if ! isgcp /etc/google_system; then
-    load_csi
-    reload_interfaces
-    load_site_init
+    # vshasta does not need certain parts of pit-init or are they incompatible with it
+    if ! isgcp; then
+        load_csi
+        reload_interfaces
+        load_site_init
+    fi
     load_packages
-  fi
     load_and_start_systemd
     load_ntp
 }


### PR DESCRIPTION
### Summary and Scope

- Fixes: CASMINST-6859

#### Issue Type

- Bugfix Pull Request

Call to `load_packages()` function was located inside condition, which only applies it to non GCP systems. This call is also needed in vShasta.

### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [x] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
Ran `pit-init.sh` twice on vShasta system. Ensured successful script execution and checked output from `load_packages` function:

    Using cloud-init.yaml from the CSM release tarball: /var/www/ephemeral/csm-1.5.1-rc.3/rpm/cloud-init.yaml
    2024/05/03 20:12:49 Patched cloud-init seed data in place
 
### Risks and Mitigations
 
Low risk - only changes behavior in a block specific to vShasta.