### PR TITLE
MTL-2554 Uppercase DNSMasq files

### DIFF
--- a/bin/csi-pxe-bond0.sh
+++ b/bin/csi-pxe-bond0.sh
@@ -2,7 +2,7 @@
 
 # MIT License
 # 
-# (C) Copyright [2022] Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022, 2025 Hewlett Packard Enterprise Development LP
 # 
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -36,7 +36,7 @@ range_start="$2"
 range_end="$3"
 lease_ttl="${4:-10m}"
 
-cat << EOF > /etc/dnsmasq.d/mtl.conf
+cat << EOF > /etc/dnsmasq.d/MTL.conf
 # MTL:
 server=/mtl/
 address=/mtl/

--- a/bin/csi-pxe-hmn.sh
+++ b/bin/csi-pxe-hmn.sh
@@ -2,7 +2,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2022 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2022, 2025 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -36,7 +36,7 @@ range_start="$2"
 range_end="$3"
 lease_ttl="${4:-10m}"
 
-cat << EOF > /etc/dnsmasq.d/hmn.conf
+cat << EOF > /etc/dnsmasq.d/HMN.conf
 # HMN:
 server=/hmn/
 address=/hmn/


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: MTL-2554 (CAST-37780)

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
The DNSMasq files generated by `csi-pxe-bond0.sh` and `csi-pxe-hmn.sh` are conflicting with generated files from the CSM installation.

These scripts are invoked as part of a fresh install operation for collecting MAC addresses, and therefore are not part of a reinstallation (where MAC addresses are already known). The scripts may also be ran after hardawre changes.

The files generated by these scripts are intended to be replaced by the CSM pre-installation. When `pit-init.sh` is invoked, new `MTL.conf` and `HMN.conf` files are created and copied into `/etc/dnsmasq.d`.

These files can not coexist with the generated files from `pit-init.sh` as they contain conflicting parameters.

This change modifies the casing on the file names, allowing them to be replaced/clobbered by the pre-installation.

This problem has been lurking for a long time. These files were originally lower cased in the PIT (and IIRC in CSI) during CSM's early days. At some point they changed to capital letters, and these scripts were neglected.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [ ] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!---
    Example:
    
    This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
    is resolved and the overall risk of fatal failures is reduced.
    
    -->
